### PR TITLE
✨ FEAT: chat store

### DIFF
--- a/src/components/chatview-components/ChatRoom.vue
+++ b/src/components/chatview-components/ChatRoom.vue
@@ -30,7 +30,7 @@
           <div class="chat-box-list-name-left-icon" @click="isActiveDropdown = !isActiveDropdown">
             {{ !isActiveDropdown ? '⊕' : '⊖' }}
           </div>
-          <!-- 
+          <!--
           <DropdownMenu v-if="isActiveDropdown" style="width: 400px">
             <template #dropdown-item>
               <BasicListItem
@@ -66,13 +66,14 @@
     <div v-else class="chat-box-list-name">
       <div class="chat-box-list-name-left-word">{{ props.chatInfo.name }}님과의 대화</div>
     </div>
-    <MessageList :chats="props.chatInfo.chats" />
+    <MessageList :chats="getChats" />
     <ChatInputBox @response="newMessage => addChat(newMessage)" :maxLength="150" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { watch, ref } from 'vue';
+import { watch, ref, computed } from 'vue';
+
 // import JoinChannelPasswordModal from '@/components/chatview-components/modals/JoinChannelPasswordModal.vue';
 import ManageChannelMemberModal from '@/components/chatview-components/modals/ManageChannelMemberModal.vue';
 import ChangeChannelPasswordModal from '@/components/chatview-components/modals/ChangeChannelPasswordModal.vue';
@@ -85,12 +86,16 @@ import ChatInputBox from '@/components/chatview-components/ChatInputBox.vue';
 // import BasicListItem from '@/components/BasicListItem.vue';
 import type { ChatInfo } from '@/interfaces/ChatInfo.interface';
 import type { User } from '@/interfaces/User.interface';
+import { useChatStore } from '@/stores/chat.store';
+import { loginStore } from '@/main';
+import type { Chat } from '@/interfaces/Chat.interface';
 
 const isSelect = ref<boolean>(false);
 const modalName = ref<string>('');
 const isActiveDropdown = ref<boolean>(false);
 
 const props = defineProps<{ chatInfo: ChatInfo; friends: User[] }>();
+const chatStore = useChatStore();
 
 watch(
   () => props.chatInfo,
@@ -103,19 +108,20 @@ const setModal: Function = (name: string) => {
   modalName.value = name;
 };
 
-const addChat: Function = (newMessage: string) => {
-  props.chatInfo.chats = [
-    ...props.chatInfo.chats,
-    {
-      id: 1,
-      username: 'kanghyki',
-      avatarURL: '',
-      message: newMessage,
-      date: new Date(),
-    },
-  ];
-  props.chatInfo.chats = props.chatInfo.chats;
+const addChat = (newMessage: string) : void => {
+  const newChat: Chat = {
+    id: loginStore.id,
+    username: loginStore.name,
+    avatarURL: loginStore.avatarURL,
+    message: newMessage,
+    date: new Date(),
+  };
+  chatStore.addChat(props.chatInfo.id, newChat);
 };
+
+const getChats = computed((): Chat[] => {
+  return chatStore.getChatById(props.chatInfo.id);
+});
 </script>
 
 <style scoped>

--- a/src/interfaces/ChatRoom.interface.ts
+++ b/src/interfaces/ChatRoom.interface.ts
@@ -1,0 +1,18 @@
+export interface ChatRoom {
+  id: number;
+  name: string;
+  hasPassword: boolean;
+}
+
+export interface ChatRoomCreate {
+  userId: number | null;
+  roomName: string | null;
+  roomMode: string;
+  password: string | null;
+}
+
+export interface ChatRoomMode {
+  roomId: number;
+  roomMode: string;
+  password: string | null;
+}

--- a/src/interfaces/ChatUser.interface.ts
+++ b/src/interfaces/ChatUser.interface.ts
@@ -1,0 +1,12 @@
+export interface ChatUserState {
+    userId: number;
+    roomId: number;
+    state: string;
+    muteTime: string;
+}
+
+export interface ChatUserRole {
+  userId: number;
+  roomId: number;
+  role: string;
+}

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia';
+import type { Chat } from '@/interfaces/Chat.interface';
+
+interface ChatState {
+  chatRooms: { [id: number]: Chat[] };
+}
+
+export const useChatStore = defineStore('chat', {
+  state: (): ChatState => ({
+    chatRooms: {},
+  }),
+  getters: {
+    getChatById:
+      state =>
+      (id: number): Chat[] => {
+        return state.chatRooms[id] || ([] as Chat[]);
+      },
+  },
+  actions: {
+    addChatRoom(id: number, newChat: Chat) {
+      this.chatRooms[id] = [newChat];
+    },
+    addChat(id: number, newChat: Chat) {
+      const chatRoom = this.chatRooms[id];
+      if (chatRoom) {
+        chatRoom.push(newChat);
+      }
+      else {
+        this.addChatRoom(id, newChat);
+      }
+    },
+    deleteChatRoom(id: number) {
+      delete this.chatRooms[id];
+    },
+    handleJoinEvent(event: CustomEvent<{ id: number; newChat: Chat }>) {
+      const { id, newChat } = event.detail;
+      this.addChatRoom(id, newChat);
+    },
+    handleMessageEvent(event: CustomEvent<{ id: number; newChat: Chat }>) {
+      const { id, newChat } = event.detail;
+      this.addChat(id, newChat);
+    },
+    handleLeaveEvent(event: CustomEvent<{ id: number }>) {
+      const { id } = event.detail;
+      this.deleteChatRoom(id);
+    },
+  },
+});


### PR DESCRIPTION
## [Note] 예상과 달라진 점
- chat 같은 경우 sessionStorage 사용하기로 했는데, 생명 주기가 pinia의 state 와 같음
    - 그래서 저장하는거 뺐습니다
    - 마찬가지로, 스토리지를 읽어 올 필요도 없어서 뺐습니다


## Discussion
1. 인터페이스
  - 1.1 파일 합칠지
      - ex. User.interface.ts, UserInfo.interface.ts, UserGameHistory.ts 를 User.interface.ts 로 합치기
    - 1.2 속성이 2개 뿐인 것도 인터페이스 만들지
2. 빼먹은 req
  - 2.1 채팅 룸 리스트 요청에서 roomMode 필요
      - onwer 의 경우 채널 모드 변경 view 를 정할 수 없음
      - hasPassword 대신 roomMode 가져올까요? -> OK
  - 2.2 socket message 받을 때도 avatarURL 받기
        - 소켓명세 확인해봤는데 없습니다. 추가 요청할까요? -> OK
        - 아니면 어차피 몇명 없으니까 foreach 나 map 으로 돌면서 id로 찾을까요? -> X
3. ChatInfo 의 chats 빼야 하는데 작업 들어가기 전에 이 브랜치에서 고칠까요?
    - 대신 fetchChat 주석처리

---
## [기타 사항] socket 때 할 일 미리보기
- ChatRoom.vue 의 `addChat`(본인이 치는 채팅)은 현재는 loginStore 사용해서 넣어놨지만, socket message emit 으로 고쳐야함. 아마 이름도 `sendChat` 이 아닐까 싶음
- 남의 메시지든 본인 메시지든 소켓 message event 에서 `chatStore.handleMessageEvent()` 를 사용해서 브라우저에 띄워줘야함
  - 이 경우, 자기 자신 mute 도 알아서 걸러짐