### PR TITLE
✨ FEAT: game interface

### DIFF
--- a/src/components/gameview-components/GameMatching.vue
+++ b/src/components/gameview-components/GameMatching.vue
@@ -25,7 +25,7 @@ import { useGameStore } from '@/stores/game.store';
 const gameStore = useGameStore();
 
 onMounted(() => {
-  if (gameStore.opponent) {
+  if (gameStore.matchInfo) {
     gameStore.setStatus('상대방대기');
   } else gameStore.setStatus('게임설정');
 });

--- a/src/components/gameview-components/GameScreen.vue
+++ b/src/components/gameview-components/GameScreen.vue
@@ -1,22 +1,22 @@
 <template>
   <div class="game-ui-continer">
     <div class="user-info-div">
-      <AvatarItem :username="loginStore.name" :avartarUrl="loginStore.avatarURL" imgSize="100" />
+      <AvatarItem :username="leftUser?.name" :avartarUrl="leftUser?.avatarURL" imgSize="100" />
     </div>
     <span class="score-div">{{ 5 }} : {{ 4 }}</span>
     <div class="user-info-div">
-      <AvatarItem :username="gameStore.opponent?.name" :avartarUrl="gameStore.opponent?.avatarURL" imgSize="100" />
+      <AvatarItem :username="rightUser?.name" :avartarUrl="rightUser?.avatarURL" imgSize="100" />
     </div>
   </div>
   <div class="table-div">
     <div class="stick-div" />
     <div v-if="!gameStore.isGameConnected" class="user-info-div bold">
       {{ 'Lose🍂' }} <br />
-      {{ 1899 - 12 }} ({{ -12 }})
+      {{ (leftUser?.rating as number) - 12 }} ({{ -12 }})
     </div>
     <div class="net-div" />
     <div v-if="!gameStore.isGameConnected" class="user-info-div bold">
-      {{ 'Win👑' }} <br />{{ 1899 + 12 }} (+{{ 12 }})
+      {{ 'Win👑' }} <br />{{ (rightUser?.rating as number) + 12 }} (+{{ 12 }})
     </div>
     <div class="stick-div" />
   </div>
@@ -28,11 +28,12 @@
 <script setup lang="ts">
 import AvatarItem from '@/components/common/AvatarItem.vue';
 
-import { useLoginStore } from '@/stores/login.store';
 import { useGameStore } from '@/stores/game.store';
 
-const loginStore = useLoginStore();
 const gameStore = useGameStore();
+
+const leftUser = gameStore.matchInfo?.leftUser;
+const rightUser = gameStore.matchInfo?.rightUser;
 
 // endGame - result
 const tmp1 = () => {

--- a/src/components/gameview-components/modals/GameConfirmationModal.vue
+++ b/src/components/gameview-components/modals/GameConfirmationModal.vue
@@ -31,7 +31,7 @@ const acceptGame = () => {
 
 const refuseGame = () => {
   gameStore.setStatus('매칭중');
-  gameStore.setOpponent(null);
+  gameStore.setMatchInfo(null);
 };
 </script>
 

--- a/src/components/gameview-components/modals/GameRefusedModal.vue
+++ b/src/components/gameview-components/modals/GameRefusedModal.vue
@@ -15,7 +15,7 @@ const gameStore = useGameStore();
 
 onMounted(() => {
   setTimeout(() => {
-    gameStore.opponent = null;
+    gameStore.setMatchInfo(null);
     gameStore.setStatus('매칭중');
   }, 3000);
 });

--- a/src/components/gameview-components/modals/GameStartingModal.vue
+++ b/src/components/gameview-components/modals/GameStartingModal.vue
@@ -3,14 +3,14 @@
     <template #body>
       <div class="body-container">
         <div class="user-info-div">
-          <AvatarItem :username="loginStore.name" :avartarUrl="loginStore.avatarURL" imgSize="100">
-            <span class="bold">1899</span>
+          <AvatarItem :username="leftUser?.name" :avartarUrl="leftUser?.avatarURL" imgSize="100">
+            <span class="bold">{{ leftUser?.rating }}</span>
           </AvatarItem>
         </div>
         <span class="verse">vs</span>
         <div class="user-info-div">
-          <AvatarItem :username="gameStore.opponent?.name" :avartarUrl="gameStore.opponent?.avatarURL" imgSize="100">
-            <span class="bold">1899</span>
+          <AvatarItem :username="rightUser?.name" :avartarUrl="rightUser?.avatarURL" imgSize="100">
+            <span class="bold">{{ rightUser?.rating }}</span>
           </AvatarItem>
         </div>
       </div>
@@ -22,11 +22,12 @@
 import Modal from '@/components/Modal.vue';
 import AvatarItem from '@/components/common/AvatarItem.vue';
 
-import { useLoginStore } from '@/stores/login.store';
 import { useGameStore } from '@/stores/game.store';
 
-const loginStore = useLoginStore();
 const gameStore = useGameStore();
+
+const leftUser = gameStore.matchInfo?.leftUser;
+const rightUser = gameStore.matchInfo?.rightUser;
 </script>
 
 <style>

--- a/src/components/gameview-components/modals/WaitingForOpponentModal.vue
+++ b/src/components/gameview-components/modals/WaitingForOpponentModal.vue
@@ -25,7 +25,20 @@ const timeout = () => {
 };
 
 const tmp = () => {
-  gameStore.setOpponent({ id: -1, name: 'hyeongki', avatarURL: '' });
+  gameStore.setMatchInfo({
+    result: true,
+    leftUser: {
+      name: 'chaejkim',
+      avatarURL: 'https://ca.slack-edge.com/T039P7U66-U02LNN8QWJV-4c936417baf6-512',
+      rating: 1899,
+    },
+    rightUser: {
+      name: 'hyeongki',
+      avatarURL: 'https://ca.slack-edge.com/T039P7U66-U035MTQ4U4T-9333cd362cf2-512',
+      rating: 1899,
+    },
+    gameroomID: 'roomidhash',
+  });
   gameStore.setStatus('게임시작');
 };
 

--- a/src/components/gameview-components/modals/WaitingForOpponentModal.vue
+++ b/src/components/gameview-components/modals/WaitingForOpponentModal.vue
@@ -44,7 +44,7 @@ const tmp = () => {
 
 onMounted(() => {
   setTimeout(() => {
-    gameStore.initGame();
+    gameStore.isStatusMatched('게임시작') ? gameStore.initGame() : gameStore.setMatchInfo(null);
   }, gameStore.atReadyTime.getTime() - new Date().getTime());
 });
 </script>

--- a/src/interfaces/game/GameMatch.interface.ts
+++ b/src/interfaces/game/GameMatch.interface.ts
@@ -1,0 +1,8 @@
+import type { GameUser } from '@/interfaces/game/GameUser.interface';
+
+export interface GameMatch {
+  result: boolean;
+  leftUser: GameUser;
+  rightUser: GameUser;
+  gameroomID: string;
+}

--- a/src/interfaces/game/GameUser.interface.ts
+++ b/src/interfaces/game/GameUser.interface.ts
@@ -1,0 +1,5 @@
+export interface GameUser {
+  name: string;
+  avatarURL: string;
+  rating: number;
+}

--- a/src/stores/game.store.ts
+++ b/src/stores/game.store.ts
@@ -1,30 +1,23 @@
 import { defineStore } from 'pinia';
-import type { User } from '@/interfaces/user/User.interface';
+import type { GameMatch } from '@/interfaces/game/GameMatch.interface';
 
 interface GameState {
   isMatched: boolean;
-  isGameConnected: boolean;
   status: number;
-  option: number;
   atReadyTime: Date;
-  opponent: User | null;
+  isGameConnected: boolean;
+  option: number;
+  matchInfo: GameMatch | null;
 }
-
-// export interface UserInfoGame {
-//   id: number;
-//   name: string;
-//   avatarURL: string;
-//   rate: number;
-// }
 
 export const useGameStore = defineStore('game', {
   state: (): GameState => ({
     isMatched: false,
-    isGameConnected: true,
     status: 0,
-    option: 0,
     atReadyTime: new Date(0),
-    opponent: null,
+    isGameConnected: true,
+    option: 0,
+    matchInfo: null,
   }),
   getters: {
     isStatusMatched:
@@ -43,8 +36,8 @@ export const useGameStore = defineStore('game', {
     setReadyTime(ms: number = 5000): void {
       this.atReadyTime = new Date(new Date().getTime() + ms);
     },
-    setOpponent(user: User | null): void {
-      this.opponent = user;
+    setMatchInfo(matchInfo: GameMatch | null): void {
+      this.matchInfo = matchInfo;
     },
     initGame(): void {
       this.isMatched = true;
@@ -53,7 +46,7 @@ export const useGameStore = defineStore('game', {
     endGame(): void {
       this.isMatched = false;
       this.isGameConnected = false;
-      this.opponent = null;
+      this.matchInfo = null;
     },
   },
 });

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -1,11 +1,12 @@
 <template>
-  <GameMatching v-if="!gameStore.isMatched" />
+  <GameMatching v-if="!isMatched" />
   <div v-else class="game-screen-div">
     <GameScreen />
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 
 import GameMatching from '@/components/gameview-components/GameMatching.vue';
 import GameScreen from '@/components/gameview-components/GameScreen.vue';
@@ -13,6 +14,10 @@ import GameScreen from '@/components/gameview-components/GameScreen.vue';
 import { useGameStore } from '@/stores/game.store';
 
 const gameStore = useGameStore();
+
+const isMatched = computed(() => {
+  return gameStore.isMatched;
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
#65 에서 브랜치 땀 (회의 결과에 따라 인터페이스가 바뀌는 경우, 해당 작업이 쓰이지 않을 수 있어서 따로 풀리퀘 올림)

- 소켓 명세에 있는 타입의 인터페이스 추가
    - `GameUser`  name, avatarURL, rating
    - `GameMatch`  result, leftUser, rightUser, gameRoomID 