### PR TITLE
✨ FEAT: 프로필 설정 및 변경

### DIFF
--- a/src/components/BasicListItem.vue
+++ b/src/components/BasicListItem.vue
@@ -38,7 +38,7 @@ const props = defineProps({
   iconButtons: { type: Array<IconButton>, default: [] as IconButton[] },
 });
 
-const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+const avatarURL = import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 
 const emits = defineEmits<{
   (e: 'onMousePosition', event: MouseEvent): void;

--- a/src/components/BasicListItem.vue
+++ b/src/components/BasicListItem.vue
@@ -2,7 +2,7 @@
   <li class="list-element-container">
     <div class="list-element-info-container">
       <div v-if="'avatarURL' in props.item" class="list-element-avatar profileText">
-        <img :src="props.item.avatarURL || avatarURL" />
+        <AvatarItem :avartarUrl="props.item.avatarURL" imgSize="40" />
       </div>
       <div>
         <span>{{ props.item?.name }}</span>
@@ -22,6 +22,7 @@
 </template>
 
 <script setup lang="ts">
+import AvatarItem from '@/components/common/AvatarItem.vue';
 import type { IconButton } from '@/interfaces/IconButton.interface';
 import type { IconEmitResponse } from '@/interfaces/IconEmitResponse.interface';
 import type { FriendInfo } from '@/interfaces/FriendsInfo.interface';
@@ -37,8 +38,6 @@ const props = defineProps({
   clickEvent: { type: String, default: '' },
   iconButtons: { type: Array<IconButton>, default: [] as IconButton[] },
 });
-
-const avatarURL = import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 
 const emits = defineEmits<{
   (e: 'onMousePosition', event: MouseEvent): void;

--- a/src/components/BasicListItem.vue
+++ b/src/components/BasicListItem.vue
@@ -2,7 +2,7 @@
   <li class="list-element-container">
     <div class="list-element-info-container">
       <div v-if="'avatarURL' in props.item" class="list-element-avatar profileText">
-        <img :src="props.item.avatarURL !== '' ? props.item.avatarURL : ''" />
+        <img :src="props.item.avatarURL || avatarURL" />
       </div>
       <div>
         <span>{{ props.item?.name }}</span>
@@ -37,6 +37,8 @@ const props = defineProps({
   clickEvent: { type: String, default: '' },
   iconButtons: { type: Array<IconButton>, default: [] as IconButton[] },
 });
+
+const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
 
 const emits = defineEmits<{
   (e: 'onMousePosition', event: MouseEvent): void;

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -11,7 +11,7 @@
       <p>비로그인</p>
     </div>
     <div v-else class="userInfo" @mouseleave="isUserDropdownMenu = false" @mouseenter="isUserDropdownMenu = true">
-      <img :src="loginStore?.avatarURL" class="profileImage" />
+      <AvatarItem class="userInfo-img" :avartarUrl="loginStore?.avatarURL" imgSize="55" />
       <p>
         {{ loginStore?.name }}
         <DropdownMenu v-if="isUserDropdownMenu" style="width: 100%">
@@ -43,8 +43,9 @@
 </template>
 
 <script setup lang="ts">
-import DropdownMenu from './dropdown-component/DropdownMenu.vue';
-import DropdownMenuItem from './dropdown-component/DropdownMenuItem.vue';
+import AvatarItem from '@/components/common/AvatarItem.vue';
+import DropdownMenu from '@/components/dropdown-component/DropdownMenu.vue';
+import DropdownMenuItem from '@/components/dropdown-component/DropdownMenuItem.vue';
 
 const isUserDropdownMenu = ref<boolean>(false);
 import { useLoginStore } from '@/stores/login.store';
@@ -144,7 +145,7 @@ const links = [
   text-decoration: none;
 }
 
-.userInfo img {
+.userInfo-img {
   height: 55px;
   width: 55px;
   border-radius: 50%;

--- a/src/components/chatview-components/MessageBox.vue
+++ b/src/components/chatview-components/MessageBox.vue
@@ -31,7 +31,7 @@ import type { Chat } from '@/interfaces/chat/Chat.interface';
 
 const loginStore = useLoginStore();
 const loginUsername = ref(loginStore?.name);
-const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+const avatarURL = import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 
 const props = defineProps<{ chat: Chat }>();
 

--- a/src/components/chatview-components/MessageBox.vue
+++ b/src/components/chatview-components/MessageBox.vue
@@ -2,7 +2,7 @@
   <div class="chat-box">
     <div class="chat-info-line">
       <div class="chat-info-line-box">
-        <img :src="props.chat.avatarURL !== '' ? props.chat.avatarURL : ''" class="user-avatar" />
+        <img :src="props.chat.avatarURL || avatarURL" class="user-avatar" />
       </div>
       <div class="chat-info-line-text">
         <p
@@ -31,6 +31,7 @@ import type { Chat } from '@/interfaces/chat/Chat.interface';
 
 const loginStore = useLoginStore();
 const loginUsername = ref(loginStore?.name);
+const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
 
 const props = defineProps<{ chat: Chat }>();
 

--- a/src/components/chatview-components/MessageBox.vue
+++ b/src/components/chatview-components/MessageBox.vue
@@ -2,7 +2,7 @@
   <div class="chat-box">
     <div class="chat-info-line">
       <div class="chat-info-line-box">
-        <img :src="props.chat.avatarURL || avatarURL" class="user-avatar" />
+        <AvatarItem class="user-avatar" :avartarUrl="props.chat.avatarURL" imgSize="50" />
       </div>
       <div class="chat-info-line-text">
         <p
@@ -26,12 +26,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import AvatarItem from '../common/AvatarItem.vue';
 import { useLoginStore } from '@/stores/login.store';
 import type { Chat } from '@/interfaces/chat/Chat.interface';
 
 const loginStore = useLoginStore();
 const loginUsername = ref(loginStore?.name);
-const avatarURL = import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 
 const props = defineProps<{ chat: Chat }>();
 

--- a/src/components/common/AvatarItem.vue
+++ b/src/components/common/AvatarItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <img class="avatar-img" :src="props.avartarUrl" :style="avatarStyle" />
+    <img class="avatar-img" :src="props.avartarUrl || avatarURL" :style="avatarStyle" />
     <div class="nickname-div">{{ props.username }}</div>
     <slot />
   </div>
@@ -21,6 +21,8 @@ const props = defineProps({
     default: '300',
   },
 });
+
+const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
 
 const avatarStyle = {
   minWidth: `${props.imgSize}px`,

--- a/src/components/common/AvatarItem.vue
+++ b/src/components/common/AvatarItem.vue
@@ -22,7 +22,7 @@ const props = defineProps({
   },
 });
 
-const avatarURL = import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+const avatarURL = import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 
 const avatarStyle = {
   minWidth: `${props.imgSize}px`,

--- a/src/components/common/UploadImage.vue
+++ b/src/components/common/UploadImage.vue
@@ -18,8 +18,8 @@ const props = defineProps({
 });
 
 const loginStore = useLoginStore();
-
-const previewImage = ref<string>(loginStore.avatarURL);
+const avatarURL = loginStore.avatarURL || import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+const previewImage = ref<string>(avatarURL);
 
 const emits = defineEmits<{
   (e: 'update:modelValue', image: File): void;

--- a/src/components/common/UploadImage.vue
+++ b/src/components/common/UploadImage.vue
@@ -3,7 +3,7 @@
     <img :src="previewImage" />
     <label>
       <BasicButton class="buttonStyle" text="Upload New Avatar" />
-      <input :value="props.uploadedFile" type="file" @change="updateImg" accept="image/*" />
+      <input :value="props.uploadedFile" type="file" @change="updateImg" accept="image/jpg, image/jpeg, image/png" />
     </label>
   </div>
 </template>

--- a/src/components/common/UploadImage.vue
+++ b/src/components/common/UploadImage.vue
@@ -18,7 +18,7 @@ const props = defineProps({
 });
 
 const loginStore = useLoginStore();
-const avatarURL = loginStore.avatarURL || import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+const avatarURL = loginStore.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
 const previewImage = ref<string>(avatarURL);
 
 const emits = defineEmits<{

--- a/src/components/common/UploadImage.vue
+++ b/src/components/common/UploadImage.vue
@@ -1,25 +1,37 @@
 <template>
   <div class="wrap">
-    <img :src="loginStore.avatarURL" />
+    <img :src="previewImage" />
     <label>
       <BasicButton class="buttonStyle" text="Upload New Avatar" />
-      <input type="file" @change="addImage" accept="image/*" />
+      <input :value="props.uploadedFile" type="file" @change="updateImg" accept="image/*" />
     </label>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useLoginStore } from '@/stores/login.store';
 import BasicButton from '@/components/BasicButton.vue';
 
+const props = defineProps({
+  uploadedFile: { type: File, default: undefined },
+});
+
 const loginStore = useLoginStore();
 
-const emits = defineEmits<{ (e: 'image', image: File): void }>();
+const previewImage = ref<string>(loginStore.avatarURL);
 
-const addImage = (e: Event) => {
-  const file = (e.target as HTMLInputElement).files;
+const emits = defineEmits<{
+  (e: 'update:modelValue', image: File): void;
+}>();
 
-  if (file) emits('image', file[0]);
+const updateImg = (e: Event) => {
+  const file = (e.target as HTMLInputElement).files?.[0];
+
+  if (file) {
+    emits('update:modelValue', file);
+    previewImage.value = URL.createObjectURL(file);
+  }
 };
 </script>
 

--- a/src/components/common/UploadImage.vue
+++ b/src/components/common/UploadImage.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useLoginStore } from '@/stores/login.store';
 import BasicButton from '@/components/BasicButton.vue';
 
@@ -18,8 +18,11 @@ const props = defineProps({
 });
 
 const loginStore = useLoginStore();
-const avatarURL = loginStore.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
-const previewImage = ref<string>(avatarURL);
+const previewImage = ref<string>('');
+
+onMounted(() => {
+  previewImage.value = loginStore.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
+});
 
 const emits = defineEmits<{
   (e: 'update:modelValue', image: File): void;

--- a/src/components/signin-components/SetProfile.vue
+++ b/src/components/signin-components/SetProfile.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="getInfoWrap">
-    <UploadImage @image="getimage" />
+    <UploadImage v-model="uploadedFile" />
     <div class="setProfile">
       <a>닉네임 설정</a>
       <TextInputBox
@@ -38,16 +38,11 @@ import UploadImage from '../common/UploadImage.vue';
 import { UserService } from '@/services/user.service';
 
 const username = ref<string>('');
-const file = ref<File | undefined>(undefined);
+const uploadedFile = ref<File | undefined>(undefined);
 const isCheckAuth = ref<boolean>(false);
 const router = useRouter();
 const modalStore = useModalStore();
 const loginStore = useLoginStore();
-
-const getimage = (image: File): void => {
-  file.value = image;
-  loginStore.avatarURL = URL.createObjectURL(image);
-};
 
 const submitNickname: Function = async (): Promise<void> => {
   if (username.value.length === 0) {
@@ -72,8 +67,8 @@ const submitNickname: Function = async (): Promise<void> => {
       const formData = new FormData();
       formData.append('name', username.value);
       formData.append('isAuth', String(isCheckAuth.value));
-      if (file.value) {
-        formData.append('avatar', file.value);
+      if (uploadedFile.value) {
+        formData.append('avatar', uploadedFile.value);
       }
       await UserService.setUserProfile(formData);
       loginStore.isLogin = true;

--- a/src/components/signin-components/SetProfile.vue
+++ b/src/components/signin-components/SetProfile.vue
@@ -9,7 +9,7 @@
             username = e;
           }
         "
-        :placeholderText="loginStore?.name"
+        :placeholderText="defaultName"
         type="name"
         :maxLength="15"
         required
@@ -28,7 +28,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import TextInputBox from '@/components/TextInputBox.vue';
 import BasicButton from '@/components/BasicButton.vue';
@@ -43,9 +43,13 @@ import { LoginService } from '@/services/login.service';
 const username = ref<string>('');
 const uploadedFile = ref<File | undefined>(undefined);
 const isCheckAuth = ref<boolean>(false);
+
+const route = useRoute();
 const router = useRouter();
 const modalStore = useModalStore();
 const loginStore = useLoginStore();
+
+const defaultName = String(route.query.name);
 
 const isValidFrom = (): boolean => {
   if (username.value.length && username.value.length < 5) {
@@ -62,7 +66,7 @@ const isValidFrom = (): boolean => {
 
 const createFormData = (): FormData => {
   const formData = new FormData();
-  formData.append('name', username.value || loginStore.name);
+  formData.append('name', username.value || defaultName);
   formData.append('isAuth', String(isCheckAuth.value));
   if (uploadedFile.value) {
     formData.append('avatar', uploadedFile.value);

--- a/src/components/signin-components/SetProfile.vue
+++ b/src/components/signin-components/SetProfile.vue
@@ -38,6 +38,8 @@ import { useLoginStore } from '@/stores/login.store';
 import { useModalStore } from '@/stores/modal.store';
 // services
 import { UserService } from '@/services/user.service';
+import { LoginService } from '@/services/login.service';
+
 const username = ref<string>('');
 const uploadedFile = ref<File | undefined>(undefined);
 const isCheckAuth = ref<boolean>(false);
@@ -73,8 +75,8 @@ const submitFrom = async (): Promise<void> => {
   try {
     const formData = createFormData();
     await UserService.setUserProfile(formData);
-    loginStore.isLogin = true;
-    loginStore.name = username.value;
+    const loginInfo = await LoginService.getUserInfo();
+    loginStore.setLogin(loginInfo);
     if (username.value.length === 0) {
       modalStore.on({
         title: '알림',

--- a/src/components/signin-components/SetProfile.vue
+++ b/src/components/signin-components/SetProfile.vue
@@ -21,22 +21,23 @@
       <span class="checkmark"></span>
     </label>
     <div class="submitButton">
-      <BasicButton @click="submitNickname()" text="완료" />
+      <BasicButton @click="submitFrom()" text="완료" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router';
-import { useLoginStore } from '@/stores/login.store';
-import { useModalStore } from '@/stores/modal.store';
 import { ref } from 'vue';
+import { useRouter } from 'vue-router';
 
 import TextInputBox from '@/components/TextInputBox.vue';
 import BasicButton from '@/components/BasicButton.vue';
 import UploadImage from '../common/UploadImage.vue';
+// stores
+import { useLoginStore } from '@/stores/login.store';
+import { useModalStore } from '@/stores/modal.store';
+// services
 import { UserService } from '@/services/user.service';
-
 const username = ref<string>('');
 const uploadedFile = ref<File | undefined>(undefined);
 const isCheckAuth = ref<boolean>(false);
@@ -44,47 +45,57 @@ const router = useRouter();
 const modalStore = useModalStore();
 const loginStore = useLoginStore();
 
-const submitNickname: Function = async (): Promise<void> => {
-  if (username.value.length === 0) {
-    modalStore.on({
-      title: '알림',
-      text: '기본 닉네임이 유지됩니다.\n언제든 [유저 - 내 프로필] 에서 변경이 가능합니다.\
-      ',
-      buttonText: '홈으로',
-      buttonFunc: () => {
-        router.push('/');
-      },
-    });
-  } else if (username.value.length < 4) {
+const isValidFrom = (): boolean => {
+  if (username.value.length && username.value.length < 5) {
     modalStore.on({
       title: '알림',
       text: '최소 5글자 이상 닉네임을 설정할 수 있습니다.',
       buttonText: '닫기',
       buttonFunc: () => {},
     });
-  } else {
-    try {
-      const formData = new FormData();
-      formData.append('name', username.value);
-      formData.append('isAuth', String(isCheckAuth.value));
-      if (uploadedFile.value) {
-        formData.append('avatar', uploadedFile.value);
-      }
-      await UserService.setUserProfile(formData);
-      loginStore.isLogin = true;
-      loginStore.name = username.value;
-      router.push('/');
-    } catch (e) {
+    return false;
+  }
+  return true;
+};
+
+const createFormData = (): FormData => {
+  const formData = new FormData();
+  formData.append('name', username.value || loginStore.name);
+  formData.append('isAuth', String(isCheckAuth.value));
+  if (uploadedFile.value) {
+    formData.append('avatar', uploadedFile.value);
+  }
+  return formData;
+};
+
+const submitFrom = async (): Promise<void> => {
+  if (!isValidFrom()) return;
+  try {
+    const formData = createFormData();
+    await UserService.setUserProfile(formData);
+    loginStore.isLogin = true;
+    loginStore.name = username.value;
+    if (username.value.length === 0) {
       modalStore.on({
-        title: '오류',
-        text: '프로필 수정 중 에러 발생!',
-        buttonText: '닫기',
+        title: '알림',
+        text: '기본 닉네임이 유지됩니다.\n언제든 [유저 - 내 프로필] 에서 변경이 가능합니다.\
+      ',
+        buttonText: '홈으로',
         buttonFunc: () => {
-          loginStore.resetAll();
           router.push('/');
         },
       });
-    }
+    } else router.push('/');
+  } catch (e) {
+    modalStore.on({
+      title: '오류',
+      text: '프로필 수정 중 에러 발생!',
+      buttonText: '닫기',
+      buttonFunc: () => {
+        loginStore.resetAll();
+        router.push('/');
+      },
+    });
   }
 };
 </script>

--- a/src/components/signin-components/SetProfile.vue
+++ b/src/components/signin-components/SetProfile.vue
@@ -51,18 +51,6 @@ const loginStore = useLoginStore();
 
 const defaultName = String(route.query.name);
 
-const isValidFrom = (): boolean => {
-  if (username.value.length && username.value.length < 5) {
-    modalStore.on({
-      title: '알림',
-      text: '최소 5글자 이상 닉네임을 설정할 수 있습니다.',
-      buttonText: '닫기',
-      buttonFunc: () => {},
-    });
-    return false;
-  }
-  return true;
-};
 
 const createFormData = (): FormData => {
   const formData = new FormData();
@@ -75,7 +63,6 @@ const createFormData = (): FormData => {
 };
 
 const submitFrom = async (): Promise<void> => {
-  if (!isValidFrom()) return;
   try {
     const formData = createFormData();
     await UserService.setUserProfile(formData);
@@ -95,7 +82,7 @@ const submitFrom = async (): Promise<void> => {
   } catch (e) {
     modalStore.on({
       title: '오류',
-      text: '프로필 수정 중 에러 발생!',
+      text: String(e),
       buttonText: '닫기',
       buttonFunc: () => {
         loginStore.resetAll();

--- a/src/components/signup-components/LoginOauth.vue
+++ b/src/components/signup-components/LoginOauth.vue
@@ -17,12 +17,8 @@ const modalStore = useModalStore();
 
 onMounted(async () => {
   try {
-    const ret = await LoginService.getUserInfo();
-    const data = ret.data;
-    console.log(data);
-    loginStore.name = data.name;
-    loginStore.id = data.id;
-    loginStore.isLogin = true;
+    const data = await LoginService.getUserInfo();
+    loginStore.setLogin(data);
     router.push('/');
   } catch (e) {
     modalStore.on({

--- a/src/interfaces/login/login.interface.ts
+++ b/src/interfaces/login/login.interface.ts
@@ -1,0 +1,7 @@
+export interface LoginInfo {
+  id: number;
+  name: string;
+  avatarURL: string;
+  isAuth: boolean;
+  email: string;
+}

--- a/src/services/login.service.ts
+++ b/src/services/login.service.ts
@@ -1,10 +1,11 @@
 import { APIWithToken } from '@/services/utils/apiDecorator.utils';
 import { axiosAPI } from './utils/axiosInstance.utils';
+import type { LoginInfo } from '@/interfaces/login/login.interface';
 
 export class LoginService {
   @APIWithToken()
-  static async getUserInfo() {
+  static async getUserInfo(): Promise<LoginInfo> {
     const ret = await axiosAPI.auth().get(`http://localhost:3000/user/me`);
-    return ret;
+    return ret.data;
   }
 }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -71,7 +71,7 @@ export class UserService {
     // const ret = await axiosAPI.auth().delete('/block');
   }
 
-  static async setUserProfile(formData: FormData) {
-    return axiosAPI.auth().put(`/user`, formData);
+  static async setUserProfile(formData: FormData): Promise<void> {
+    const ret = await axiosAPI.auth().put(`/user`, formData);
   }
 }

--- a/src/stores/login.store.ts
+++ b/src/stores/login.store.ts
@@ -43,7 +43,7 @@ export const useLoginStore = defineStore('login', {
     setLogin(user: LoginInfo) {
       this.isLogin = true;
       this.name = user.name;
-      this.avatarURL = user.avatarURL;
+      this.avatarURL = user.avatarURL || import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
       this.email = user.email;
       this.isAuth = user.isAuth;
     },

--- a/src/stores/login.store.ts
+++ b/src/stores/login.store.ts
@@ -42,6 +42,7 @@ export const useLoginStore = defineStore('login', {
     },
     setLogin(user: LoginInfo) {
       this.isLogin = true;
+      this.id = user.id;
       this.name = user.name;
       this.avatarURL = user.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
       this.email = user.email;

--- a/src/stores/login.store.ts
+++ b/src/stores/login.store.ts
@@ -43,7 +43,7 @@ export const useLoginStore = defineStore('login', {
     setLogin(user: LoginInfo) {
       this.isLogin = true;
       this.name = user.name;
-      this.avatarURL = user.avatarURL || import.meta.env.VITE_APP_DEFULT_AVATAR_URL;
+      this.avatarURL = user.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
       this.email = user.email;
       this.isAuth = user.isAuth;
     },

--- a/src/stores/login.store.ts
+++ b/src/stores/login.store.ts
@@ -44,7 +44,7 @@ export const useLoginStore = defineStore('login', {
       this.isLogin = true;
       this.id = user.id;
       this.name = user.name;
-      this.avatarURL = user.avatarURL || import.meta.env.VITE_APP_DEFAULT_AVATAR_URL;
+      this.avatarURL = user.avatarURL;
       this.email = user.email;
       this.isAuth = user.isAuth;
     },

--- a/src/stores/login.store.ts
+++ b/src/stores/login.store.ts
@@ -1,12 +1,24 @@
 import { defineStore } from 'pinia';
 import type { User } from '@/interfaces/user/User.interface';
+import type { LoginInfo } from '@/interfaces/login/login.interface';
+
+interface LoginState {
+  isLogin: boolean;
+  id: number;
+  name: string;
+  avatarURL: string;
+  isAuth: boolean;
+  email: string;
+}
 
 export const useLoginStore = defineStore('login', {
-  state: () => ({
+  state: (): LoginState => ({
     isLogin: false,
     id: -1,
     name: '',
     avatarURL: '',
+    isAuth: false,
+    email: '',
   }),
   getters: {
     owner(): User {
@@ -25,6 +37,20 @@ export const useLoginStore = defineStore('login', {
       this.id = -1;
       this.name = '';
       this.avatarURL = '';
+      this.isAuth = false;
+      this.email = '';
+    },
+    setLogin(user: LoginInfo) {
+      this.isLogin = true;
+      this.name = user.name;
+      this.avatarURL = user.avatarURL;
+      this.email = user.email;
+      this.isAuth = user.isAuth;
+    },
+    updateLoginInfo(user: LoginInfo) {
+      this.name = user.name;
+      this.avatarURL = user.avatarURL;
+      this.isAuth = user.isAuth;
     },
   },
   persist: true,

--- a/src/views/MyProfileView.vue
+++ b/src/views/MyProfileView.vue
@@ -22,7 +22,7 @@
     </div>
   </div> -->
   <div class="wrap">
-    <UploadImage />
+    <UploadImage v-model="uploadedFile"/>
     <div class="p-info">
       <div class="name">
         <h3>닉네임 설정</h3>
@@ -58,7 +58,7 @@ import { ref } from 'vue';
 
 const user = { _id: '1', name: 'chaejkim', img: '1.png', email: 'chaejkim@student.42seoul.kr', isAuth: false };
 const tmp_user = { _id: '1', name: 'chaejkim', img: '1.png', email: 'chaejkim@student.42seoul.kr', isAuth: false };
-const uploadedFile = ref<File | null>(null);
+const uploadedFile = ref<File | undefined>(undefined);
 
 // const emit = defineEmits(['fileSelected']);
 

--- a/src/views/MyProfileView.vue
+++ b/src/views/MyProfileView.vue
@@ -54,19 +54,6 @@ const isCheckAuth = ref<boolean>(false);
 const loginStore = useLoginStore();
 const modalStore = useModalStore();
 
-const isValidFrom = (): boolean => {
-  if (username.value.length && username.value.length < 5) {
-    modalStore.on({
-      title: '알림',
-      text: '최소 5글자 이상 닉네임을 설정할 수 있습니다.',
-      buttonText: '닫기',
-      buttonFunc: () => {},
-    });
-    return false;
-  }
-  return true;
-};
-
 const createFormData = (): FormData => {
   const formData = new FormData();
   formData.append('name', username.value || loginStore.name);
@@ -78,7 +65,6 @@ const createFormData = (): FormData => {
 };
 
 const submitFrom = async (): Promise<void> => {
-  if (!isValidFrom()) return;
   try {
     const formData = createFormData();
     await UserService.setUserProfile(formData);
@@ -87,7 +73,7 @@ const submitFrom = async (): Promise<void> => {
   } catch (e) {
     modalStore.on({
       title: '오류',
-      text: '프로필 수정 중 에러 발생!',
+      text: String(e),
       buttonText: '닫기',
       buttonFunc: () => {
         modalStore.off();

--- a/src/views/MyProfileView.vue
+++ b/src/views/MyProfileView.vue
@@ -1,44 +1,31 @@
 <template>
-  <!-- {{ console.log(user) }}
-  <div class="p-container">
-    <Card class="p-info" :img="user.img">
-      <div class="button-slot">
-        <input type="file" class="input-file" ref="uploadedFile" @click="handleImgChange" />
-        <DButton class="upload-button" label="Upload new photo" />
-      </div>
-    </Card>
-    <div class="e-info">
-      <div class="end-align">닉네임 설정</div>
-      <span>kanghyki 만든 input box 자리 <br />글자수 제한 <br />글자수 제한 <br /> </span>
-      <div class="end-align">2차 인증</div>
-      <TButton :value="user.isAuth" />
-      <div class="end-align">인증 메일</div>
-      <div>{{ user.email }}</div>
-
-      <div class="two-buttons">
-        <DButton class="edit-button" label="완료" @click="editButton()" />
-        <DButton class="cancle-button" label="취소" @click="editButton()" />
-      </div>
-    </div>
-  </div> -->
   <div class="wrap">
-    <UploadImage v-model="uploadedFile"/>
+    <UploadImage v-model="uploadedFile" />
     <div class="p-info">
       <div class="name">
         <h3>닉네임 설정</h3>
-        <TextInputBox placeholderText="닉네임입력" type="name" :maxLength="15" required />
+        <TextInputBox
+          @response="
+            e => {
+              username = e;
+            }
+          "
+          :placeholderText="loginStore?.name"
+          type="name"
+          :maxLength="15"
+          required
+        />
       </div>
       <div class="auth">
         <h3>2차인증</h3>
-        <TButton />
+        <TButton :value="isCheckAuth" />
       </div>
       <div class="mail">
         <h3>인증메일</h3>
-        <a>hejang@student.42seoul.kr</a>
+        <a>{{ loginStore?.email }}</a>
       </div>
       <div class="two-buttons">
-        <!-- <button type="button" :disabled="src" class="test">완료</button> -->
-        <BasicButton text="완료" />
+        <BasicButton text="완료" @click="submitFrom()" />
         <BasicButton text="취소" :type="false" />
       </div>
     </div>
@@ -46,36 +33,67 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+
 import TButton from '@/components/common/ToggleButton.vue';
 import UploadImage from '@/components/common/UploadImage.vue';
 import TextInputBox from '@/components/TextInputBox.vue';
 import BasicButton from '@/components/BasicButton.vue';
-import { ref } from 'vue';
 
-// const props = defineProps({
-//   user_id: String,
-// });
+// stores
+import { useLoginStore } from '@/stores/login.store';
+import { useModalStore } from '@/stores/modal.store';
+// services
+import { UserService } from '@/services/user.service';
+import { LoginService } from '@/services/login.service';
 
-const user = { _id: '1', name: 'chaejkim', img: '1.png', email: 'chaejkim@student.42seoul.kr', isAuth: false };
-const tmp_user = { _id: '1', name: 'chaejkim', img: '1.png', email: 'chaejkim@student.42seoul.kr', isAuth: false };
 const uploadedFile = ref<File | undefined>(undefined);
+const username = ref<string>('');
+const isCheckAuth = ref<boolean>(false);
 
-// const emit = defineEmits(['fileSelected']);
+const loginStore = useLoginStore();
+const modalStore = useModalStore();
 
-const handleImgChange = (event: Event) => {
-  // this.user.img = 'profile_0.png';
-  const input = event.target as HTMLInputElement;
-  if (input.files && input.files.length) {
-    uploadedFile.value = input.files[0];
-    // emit('fileSelected', input.files[0]);
+const isValidFrom = (): boolean => {
+  if (username.value.length && username.value.length < 5) {
+    modalStore.on({
+      title: '알림',
+      text: '최소 5글자 이상 닉네임을 설정할 수 있습니다.',
+      buttonText: '닫기',
+      buttonFunc: () => {},
+    });
+    return false;
   }
-  console.log(uploadedFile.value);
+  return true;
 };
 
-const editButton = () => {
-  user.name = tmp_user.name; // TODO : name check
-  user.isAuth = tmp_user.isAuth;
-  user.img = tmp_user.img;
+const createFormData = (): FormData => {
+  const formData = new FormData();
+  formData.append('name', username.value || loginStore.name);
+  formData.append('isAuth', String(isCheckAuth.value));
+  if (uploadedFile.value) {
+    formData.append('avatar', uploadedFile.value);
+  }
+  return formData;
+};
+
+const submitFrom = async (): Promise<void> => {
+  if (!isValidFrom()) return;
+  try {
+    const formData = createFormData();
+    await UserService.setUserProfile(formData);
+    const loginInfo = await LoginService.getUserInfo();
+    loginStore.updateLoginInfo(loginInfo);
+  } catch (e) {
+    modalStore.on({
+      title: '오류',
+      text: '프로필 수정 중 에러 발생!',
+      buttonText: '닫기',
+      buttonFunc: () => {
+        modalStore.off();
+      },
+    });
+  }
 };
 </script>
 


### PR DESCRIPTION
#88 
### 작업 내용
- setProfile 함수 분리
- login store 추가
    - login store 에 2차 인증 선택여부(boolean), email(string) 추가
    - store state 업데이트시 store 액션(함수) 이용
- myProfile 에 setProfile 코드 복붙
    - 알림 내용만 좀 다름
- avatar 업로드시에 jpg jpeg png 외의 확장자 accept 해둠 (더 완벽한 처리가 있을 것 같긴 함)
- default avatarURL 사용

### Discussion
- [-] avatar 이미지 비어있을 때 프론트 처리 ~~(형키님이랑 논의 하기로 해서 남겨둔 사항)~~
    - ~~기존 이미지를 준다, 비워놓으면 백에서 처리한다 등 방법이 있음... 미정~~
    - s3 에 default.jpg 를 두고 사용
1. signin/setprofile(setProfile.vue) 과 user(myProfile.vue)에 서비스 로직이 겹치는데 util로 빼서 처리할지
2. .env 에 default avatarURL 을 넣어서 쓸지 그냥 string 으로 박아두고 export 해서 사용할지
    - +img 태그 한번 wrapping 해서 사용할지