### PR TITLE
✨  FEAT: 2차 인증 추가

### DIFF
--- a/src/components/CountdownTimer.vue
+++ b/src/components/CountdownTimer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="formatted-timde-div">
+  <div :class="{ 'formatted-timde-div': true, 'small-font': props.fontSize === 'small' ? true : false }">
     {{ formattedTime }}
   </div>
 </template>
@@ -10,6 +10,7 @@ import { ref, onMounted, onBeforeUnmount } from 'vue';
 const props = defineProps({
   targetTime: { type: Date, default: new Date() },
   timeoutMessage: { type: String },
+  fontSize: { type: String, default: 'extra-large' },
 });
 
 const emits = defineEmits(['timeout']);
@@ -49,5 +50,8 @@ onMounted(() => {
   justify-content: center;
   font: var(--extra-large);
   font-weight: bolder;
+}
+.small-font {
+  font: var(--small);
 }
 </style>

--- a/src/components/signin-components/TwoFactor.vue
+++ b/src/components/signin-components/TwoFactor.vue
@@ -14,15 +14,24 @@
       />
     </div>
     <div class="submitButton">
+      <div class="timer">
+        ⏱
+        <CountdownTimer
+          :targetTime="new Date(new Date().getTime() + 171000)"
+          @timeout="isTimeout = true"
+          fontSize="small"
+        />
+      </div>
       <BasicButton @click="submitAuthCode()" text="완료" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
+import CountdownTimer from '@/components/CountdownTimer.vue';
 import TextInputBox from '@/components/TextInputBox.vue';
 import BasicButton from '@/components/BasicButton.vue';
 // stores
@@ -44,7 +53,20 @@ const isValidCode = (): boolean => {
   return true;
 };
 
+const isTimeout = ref<boolean>(false);
+
 const submitAuthCode = async (): Promise<void> => {
+  if (isTimeout.value) {
+    modalStore.on({
+      title: '알림',
+      text: '인증 코드가 만료되었습니다.',
+      buttonText: '재발급',
+      buttonFunc: () => {
+        window.location.href = 'http://localhost:3000/login/ft';
+      },
+    });
+    return;
+  }
   if (!isValidCode()) {
     modalStore.on({
       title: '알림',
@@ -54,7 +76,6 @@ const submitAuthCode = async (): Promise<void> => {
     });
     return;
   }
-
   const token = String(route.query.token);
   const authCode: AuthCode = { code: code.value };
   await LoginService.postTwoFactor(token, authCode);
@@ -91,7 +112,17 @@ const submitAuthCode = async (): Promise<void> => {
 }
 
 .submitButton {
-  margin-left: 520px;
+  display: flex;
+  gap: 10px;
+  margin-left: 440px;
+  margin-right: 30px;
   margin-top: 30px;
+}
+
+.timer {
+  display: flex;
+  min-width: max-content;
+  align-self: center;
+  gap: 5px;
 }
 </style>

--- a/src/components/signin-components/TwoFactor.vue
+++ b/src/components/signin-components/TwoFactor.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="getInfoWrap">
+    <div class="setProfile">
+      <a>인증 번호</a>
+      <TextInputBox
+        @response="
+          e => {
+            code = e;
+          }
+        "
+        placeholderText="숫자 4자리"
+        type="text"
+        :max-length="4"
+      />
+    </div>
+    <div class="submitButton">
+      <BasicButton @click="submitAuthCode()" text="완료" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import TextInputBox from '@/components/TextInputBox.vue';
+import BasicButton from '@/components/BasicButton.vue';
+// stores
+import { useLoginStore } from '@/stores/login.store';
+import { useModalStore } from '@/stores/modal.store';
+// services
+import { LoginService, type AuthCode } from '@/services/login.service';
+
+const code = ref<string>('');
+const route = useRoute();
+const router = useRouter();
+const modalStore = useModalStore();
+const loginStore = useLoginStore();
+
+const isValidCode = (): boolean => {
+  if (code.value.length !== 4) return false;
+  const codeNum = Number(code.value);
+  if (codeNum > 9999) return false;
+  return true;
+};
+
+const submitAuthCode = async (): Promise<void> => {
+  if (!isValidCode()) {
+    modalStore.on({
+      title: '알림',
+      text: '4자리 코드를 입력해주세요.',
+      buttonText: '닫기',
+      buttonFunc: () => {},
+    });
+    return;
+  }
+
+  const token = String(route.query.token);
+  const authCode: AuthCode = { code: code.value };
+  await LoginService.postTwoFactor(token, authCode);
+  const loginInfo = await LoginService.getUserInfo();
+  loginStore.setLogin(loginInfo);
+  router.push('/');
+};
+</script>
+
+<style scoped>
+.getInfoWrap {
+  flex: 1;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  padding: 10px;
+}
+
+.setProfile {
+  display: flex;
+  flex-flow: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 30px;
+}
+
+.setProfile a {
+  color: black;
+  font-weight: 600;
+  font-size: 24px;
+  margin-right: 40px;
+  margin-left: 40px;
+  margin-bottom: 10px;
+}
+
+.submitButton {
+  margin-left: 520px;
+  margin-top: 30px;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,6 +26,11 @@ const router = createRouter({
           name: 'oauth',
           component: () => import('@/components/signup-components/LoginOauth.vue'),
         },
+        {
+          path: '2fa-auth',
+          name: '2fa-auth',
+          component: () => import('@/components/signin-components/TwoFactor.vue'),
+        },
       ],
     },
     {

--- a/src/services/login.service.ts
+++ b/src/services/login.service.ts
@@ -1,9 +1,22 @@
+import axios from 'axios';
 import { axiosGet } from './utils/axiosInstance.utils';
 import type { LoginInfo } from '@/interfaces/login/login.interface';
+
+export interface AuthCode {
+  code: string;
+}
 
 export class LoginService {
   static async getUserInfo(): Promise<LoginInfo> {
     const loginInfo: LoginInfo = await axiosGet(`http://localhost:3000/user/me`);
     return loginInfo;
+  }
+
+  static async postTwoFactor(token: String, authCode: AuthCode): Promise<void> {
+    const ret = await axios.post('http://localhost:3000/login/2fa-auth', authCode, {
+      headers: { Authorization: `Bearer ${token}` },
+      withCredentials: true,
+    });
+    if (typeof ret.data === 'string') localStorage.setItem('access-token', ret.data);
   }
 }


### PR DESCRIPTION
#91 
## 작업 내용
- 2차 인증을 위한 컴포넌트 추가 및 라우터 경로 추가
- 만료시간 타이머 (2분 50초로 고정)

## 특이 사항
- 2차 인증 http 요청시 wrapping한 axios 미사용
    - cookie 사용 허용 필요
    - 유효 시간과 요청 클라이언트 정보(id)를 담은 1회성인 token 을 사용 필요