### PR TITLE
 🐛 FIX: quit dm 시에 양측 에러 발생 수정

### DIFF
--- a/src/components/chatview-components/ChatList.vue
+++ b/src/components/chatview-components/ChatList.vue
@@ -101,7 +101,7 @@ watch(
   () => chatStore.isSelected && chatStore.removedRooms,
   () => {
     const id = chatStore.selectedID;
-    if (chatStore.removedRooms[id])
+    if (chatStore.removedRooms[id] && chatStore.rooms[id].roomMode !== 'DIRECT')
       modalStore.on({
         title: '알림',
         text: chatStore.getNotice(id),


### PR DESCRIPTION
디엠방 나갈 때 먼저 나간 사람에서 없는 룸입니다 에러 발생 & 남아있는 사람 나갈 때는 x 버튼 동작 안됨 해결