### PR TITLE
Fix: this that

### DIFF
--- a/src/components/chatview-components/ChatRoom.vue
+++ b/src/components/chatview-components/ChatRoom.vue
@@ -60,7 +60,11 @@
       </div>
     </div>
     <div v-else class="chat-box-list-name">
-      <div class="chat-box-list-name-left-word">{{ chatStore.chatRoom?.users[0]?.name && chatStore.chatRoom?.users[0]?.name }}님과의 대화</div>
+      <div class="chat-box-list-name-left-word">
+        <span class="chat-box-list-dm-name" @click="toProfile">
+          {{ chatStore.chatRoom?.users[0]?.name && chatStore.chatRoom?.users[0]?.name }}
+        </span>
+        님과의 대화</div>
     </div>
     <MessageList :chats="chatStore.chat" />
     <ChatInputBox
@@ -119,6 +123,10 @@ watch(
     newMode ? (roomMode.value = newMode) : (roomMode.value = '');
   },
 );
+
+const toProfile = () => {
+  router.push(`/users/${chatStore.chatRoom?.users[0]?.name}`)
+}
 
 const addChat = (newMessage: string): void => {
   if (chatStore.isSelected)
@@ -193,6 +201,10 @@ const inviteGame = (iconEmitResponse: IconEmitResponse) => {
   font: var(--medium);
   margin-right: 10px;
   color: var(--brown, #463f3a);
+}
+.chat-box-list-dm-name {
+  font-weight: bold;
+  cursor: pointer;
 }
 
 .chat-box-list-name-left-icon-container {

--- a/src/components/chatview-components/ChatRoom.vue
+++ b/src/components/chatview-components/ChatRoom.vue
@@ -28,7 +28,7 @@
   <div class="chat-list-container">
     <div v-if="chatStore.chatRoom?.roomMode !== RoomMode.DIRECT" class="chat-box-list-name">
       <div class="chat-box-list-name-left">
-        <div class="chat-box-list-name-left-word">{{ chatStore.chatRoom?.name }}</div>
+        <div class="chat-box-list-name-left-word" style="font-weight: bold;">{{ chatStore.chatRoom?.name }}</div>
         <div class="chat-box-list-name-left-icon-container">
           <div class="chat-box-list-name-left-icon" @click="isActiveDropdown = !isActiveDropdown">
             {{ !isActiveDropdown ? '⊕' : '⊖' }}

--- a/src/components/chatview-components/ChatRoom.vue
+++ b/src/components/chatview-components/ChatRoom.vue
@@ -60,7 +60,7 @@
       </div>
     </div>
     <div v-else class="chat-box-list-name">
-      <div class="chat-box-list-name-left-word">디엠상대 님과의 대화</div>
+      <div class="chat-box-list-name-left-word">{{ chatStore.chatRoom?.users[0]?.name && chatStore.chatRoom?.users[0]?.name }}님과의 대화</div>
     </div>
     <MessageList :chats="chatStore.chat" />
     <ChatInputBox

--- a/src/components/chatview-components/MessageBox.vue
+++ b/src/components/chatview-components/MessageBox.vue
@@ -4,7 +4,7 @@
       <div class="chat-info-line-box">
         <AvatarItem class="user-avatar" :avartarUrl="props.chat.avatarURL" imgSize="50" />
       </div>
-      <div class="chat-info-line-text">
+      <div class="chat-info-line-text"  @click="toProfile">
         <p
           :class="{
             'chat-info-line-box': !isMyMessage,
@@ -29,11 +29,17 @@ import { computed, ref } from 'vue';
 import AvatarItem from '../common/AvatarItem.vue';
 import { useLoginStore } from '@/stores/login.store';
 import type { Chat } from '@/interfaces/chat/Chat.interface';
+import { useRouter } from 'vue-router';
 
+const router = useRouter();
 const loginStore = useLoginStore();
 const loginUsername = ref(loginStore?.name);
 
 const props = defineProps<{ chat: Chat }>();
+
+const toProfile = () => {
+  router.push(`/users/${props.chat.username}`)
+}
 
 const isMyMessage = computed(() => {
   return props.chat.username === loginUsername.value;
@@ -77,6 +83,7 @@ const timeString = computed(() => {
   justify-content: center;
   align-items: flex-start;
   color: var(--brown, #463f3a);
+  cursor: pointer;
 }
 
 .chat-info-line-box {

--- a/src/components/chatview-components/MessageList.vue
+++ b/src/components/chatview-components/MessageList.vue
@@ -23,7 +23,7 @@ onMounted(() => {
 const props = defineProps<{ chats: Chat[] }>();
 
 watch(
-  () => props.chats,
+  () => props.chats.length,
   () => {
     scrollToLatestMsg();
   },

--- a/src/components/friendslist-component/FriendList.vue
+++ b/src/components/friendslist-component/FriendList.vue
@@ -63,7 +63,6 @@ const getButtonTitle = () => {
 };
 
 const updateUser = (id: number, state: string): void => {
-  for (const b of userStore.blocks) if (b.id === id) return;
   for (const user of users.value) {
     if (user.id === id) {
       user.state = state;


### PR DESCRIPTION
- DM에서 상대방 유저의 이름이 채팅방 제목에 올바르게 표시되도록 변경
- Block 된 유저의 state를 볼 수 있게 변경
- 채팅방 제목의 이름이나 메세지 박스의 이름으로 프로필 페이지로 이동할 수 있도록 변경
- 채팅방 이름을 bold로 표시하도록 변경
- 새로운 메시지 오면 자동 스크롤